### PR TITLE
Add missing `webmozart/assert` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "pheature/toggle-core": "^0.5",
         "pheature/toggle-crud-psr11-factories": "^0.5",
         "pheature/toggle-model": "^0.5",
-        "symfony/framework-bundle": "~5.0|~6.0"
+        "symfony/framework-bundle": "~5.0|~6.0",
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "doctrine/dbal": ">=2.6 || ^3.0",


### PR DESCRIPTION
Since 71f5effb58ec218e8bea2a5bcc58bb873d57fd5f `webmozart/assert` is required, but is missed in `composer.json` file.