### PR TITLE
Add missing config key

### DIFF
--- a/src/PheatureFlagsBundle.php
+++ b/src/PheatureFlagsBundle.php
@@ -22,6 +22,7 @@ final class PheatureFlagsBundle extends Bundle
 {
     private const DEFAULT_CONFIG = [
         'driver' => 'inmemory',
+        'driver_options' => [],
         'api_prefix' => '',
         'api_enabled' => false,
         'segment_types' => [


### PR DESCRIPTION
Since 71f5effb58ec218e8bea2a5bcc58bb873d57fd5f, the config key `driver_options` must exists and must be an array.