### PR TITLE
fix: load twig extension dependencies dinamically

### DIFF
--- a/src/DependencyInjection/TwigExtensionPass.php
+++ b/src/DependencyInjection/TwigExtensionPass.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pheature\Community\Symfony\DependencyInjection;
 
 use Pheature\Community\Symfony\Twig\PheatureFlagsExtension;
+use Pheature\Community\Symfony\Twig\PheatureFlagsRuntime;
+use Pheature\Core\Toggle\Read\Toggle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -18,10 +20,12 @@ final class TwigExtensionPass implements CompilerPassInterface
             return;
         }
 
-        $container->register(PheatureFlagsExtension::class, PheatureFlagsExtension::class);
+        $container->register(PheatureFlagsRuntime::class, PheatureFlagsRuntime::class)
+            ->addArgument(new Reference(Toggle::class));
+        $container->register(PheatureFlagsExtension::class, PheatureFlagsExtension::class)
+            ->addArgument(new Reference(PheatureFlagsRuntime::class));
 
         $container->findDefinition('twig')
-            ->addMethodCall('addExtension', [new Reference(PheatureFlagsExtension::class)])
-        ;
+            ->addMethodCall('addExtension', [new Reference(PheatureFlagsExtension::class)]);
     }
 }

--- a/src/Twig/PheatureFlagsExtension.php
+++ b/src/Twig/PheatureFlagsExtension.php
@@ -10,14 +10,21 @@ use Twig\TwigTest;
 
 final class PheatureFlagsExtension extends AbstractExtension
 {
+    private PheatureFlagsRuntime $runtime;
+
+    public function __construct(PheatureFlagsRuntime $runtime)
+    {
+        $this->runtime = $runtime;
+    }
+
     /**
      * @return TwigTest[]
      */
     public function getTests(): array
     {
         return [
-            new TwigTest('enabled', [PheatureFlagsRuntime::class, 'isEnabled']),
-            new TwigTest('enabled_for', [PheatureFlagsRuntime::class, 'isEnabled'], ['one_mandatory_argument' => true]),
+            new TwigTest('enabled', [$this->runtime, 'isEnabled']),
+            new TwigTest('enabled_for', [$this->runtime, 'isEnabled'], ['one_mandatory_argument' => true]),
         ];
     }
 
@@ -27,7 +34,7 @@ final class PheatureFlagsExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('is_feature_enabled', [PheatureFlagsRuntime::class, 'isFeatureEnabled']),
+            new TwigFunction('is_feature_enabled', [$this->runtime, 'isFeatureEnabled']),
         ];
     }
 }

--- a/test/Twig/PheatureFlagsExtensionTest.php
+++ b/test/Twig/PheatureFlagsExtensionTest.php
@@ -21,13 +21,21 @@ final class PheatureFlagsExtensionTest extends TestCase
 {
     public function testItShouldExposeTwoTests(): void
     {
-        $extension = new PheatureFlagsExtension(new Toggle($this->createStub(FeatureFinder::class)));
+        $extension = new PheatureFlagsExtension(
+            new PheatureFlagsRuntime(
+                new Toggle($this->createStub(FeatureFinder::class))
+            )
+        );
         $this->assertCount(2, $extension->getTests());
     }
 
     public function testItShouldExposeOneFunction(): void
     {
-        $extension = new PheatureFlagsExtension(new Toggle($this->createStub(FeatureFinder::class)));
+        $extension = new PheatureFlagsExtension(
+            new PheatureFlagsRuntime(
+                new Toggle($this->createStub(FeatureFinder::class))
+            )
+        );
         $this->assertCount(1, $extension->getFunctions());
     }
 
@@ -38,9 +46,12 @@ final class PheatureFlagsExtensionTest extends TestCase
     {
         $loader = new ArrayLoader(['index' => $template]);
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
-        $twig->addExtension(new PheatureFlagsExtension());
         $toggle = $this->createAllFeaturesEnabledToggle();
-        $twig->addRuntimeLoader(new FactoryRuntimeLoader([PheatureFlagsRuntime::class => fn() => new PheatureFlagsRuntime($toggle)]));
+        $twig->addExtension(new PheatureFlagsExtension(
+            new PheatureFlagsRuntime(
+                $toggle
+            )
+        ));
 
         $this->assertSame('yes', $twig->load('index')->render($variables));
     }


### PR DESCRIPTION
We introduce a bug in the latest release

```
[critical] Uncaught PHP Exception Twig\Error\RuntimeError: "Unable to load the "Pheature\Community\Symfony\Twig\PheatureFlagsRuntime" runtime." at /opt/app/templates/home/index.html.twig line 9
```