### PR TITLE
allow user declare segment type factories

### DIFF
--- a/src/DependencyInjection/SegmentFactoryPass.php
+++ b/src/DependencyInjection/SegmentFactoryPass.php
@@ -32,9 +32,11 @@ final class SegmentFactoryPass implements CompilerPassInterface
             Assert::string($segmentDefinition['type']);
             Assert::keyExists($segmentDefinition, 'factory_id');
             Assert::string($segmentDefinition['factory_id']);
-            $container->register($segmentDefinition['type'], $segmentDefinition['factory_id'])
-                ->setAutowired(false)
-                ->setLazy(false);
+            if (false === $container->has($segmentDefinition['type'])) {
+                $container->register($segmentDefinition['type'], $segmentDefinition['factory_id'])
+                    ->setAutowired(false)
+                    ->setLazy(false);
+            }
 
             $segmentFactory->addArgument(new Reference($segmentDefinition['type']));
         }


### PR DESCRIPTION
It allow the loading of user-defined services instead of trying to register services on our own.

It is very confusing behavior because you define the service with the same name as the loaded service, but the instance is not the one you configured.

Also, it leads to an error when the segment type constructor requires some input parameter.
  