### PR TITLE
Explicit nullable types

### DIFF
--- a/src/Twig/PheatureFlagsRuntime.php
+++ b/src/Twig/PheatureFlagsRuntime.php
@@ -22,7 +22,7 @@ final class PheatureFlagsRuntime implements RuntimeExtensionInterface
     /**
      * @throws FeatureNotFoundException
      */
-    public function isEnabled(string $feature, ConsumerIdentity $consumerIdentity = null): bool
+    public function isEnabled(string $feature, ?ConsumerIdentity $consumerIdentity = null): bool
     {
         return $this->toggle->isEnabled($feature, $consumerIdentity);
     }


### PR DESCRIPTION
Resolves (1) PHP 8.4 deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated